### PR TITLE
Makefile

### DIFF
--- a/ding_mobile.make
+++ b/ding_mobile.make
@@ -1,0 +1,13 @@
+api = 2
+core = 6.x
+
+projects[mobile_tools][subdir] = "contrib"
+projects[mobile_tools][version] = "2.3"
+ 
+projects[browscap][subdir] = "contrib"
+projects[browscap][version] = "1.5"
+ 
+projects[alternator][type] = "theme"
+projects[alternator][download][type] = "git"
+projects[alternator][download][url] = "http://github.com/dingproject/alternator.git"
+projects[alternator][download][revision] = "v1.1.0-rc2"


### PR DESCRIPTION
This PR creates an make file in the ding-mobile module, that downloads needed contrib modules and the mobile base theme.

See lighthouse ticket [1896](https://libraryding.lighthouseapp.com/projects/27862/tickets/1896-lave-make-file-til-hentning-af-mobile-moduler)
