### PR TITLE
Do not redirect DIBS callbacks on mobile pages.

### DIFF
--- a/ding_mobile/ding_mobile.strongarm.inc
+++ b/ding_mobile/ding_mobile.strongarm.inc
@@ -93,7 +93,7 @@ function ding_mobile_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'mobile_tools_redirect_exceptions';
-  $strongarm->value = '';
+  $strongarm->value = 'payment/dibs/callbackok/*';
 
   $export['mobile_tools_redirect_exceptions'] = $strongarm;
   $strongarm = new stdClass;


### PR DESCRIPTION
DIBS does not seem to follow redirects and this prevents users paying from the mobile site from having their payments registered in Ding and thus in the library system.

Lighthouse ticket [#1914](https://libraryding.lighthouseapp.com/projects/27862/tickets/1914).
