### PR TITLE
Use https for alternator

### DIFF
--- a/ding_mobile.make
+++ b/ding_mobile.make
@@ -9,5 +9,5 @@ projects[browscap][version] = "1.5"
  
 projects[alternator][type] = "theme"
 projects[alternator][download][type] = "git"
-projects[alternator][download][url] = "http://github.com/dingproject/alternator.git"
+projects[alternator][download][url] = "https://github.com/dingproject/alternator.git"
 projects[alternator][download][revision] = "v1.1.0-rc2"


### PR DESCRIPTION
Using http can fail during drush_make.

The error message during builds will be: `Unable to clone alternator from http://github.com/dingproject/alternator.git`.

Trying to clone the project manuall reveals an error: `git clone error: RPC failed; result=22, HTTP code = 400`.
