### PR TITLE
Changing to secure protocol.

### DIFF
--- a/ding_mobile.make
+++ b/ding_mobile.make
@@ -9,5 +9,5 @@ projects[browscap][version] = "1.5"
  
 projects[alternator][type] = "theme"
 projects[alternator][download][type] = "git"
-projects[alternator][download][url] = "http://github.com/dingproject/alternator.git"
+projects[alternator][download][url] = "https://github.com/dingproject/alternator.git"
 projects[alternator][download][revision] = "v1.1.0-rc2"


### PR DESCRIPTION
When trying to deploy rdb, it was hanging on cloning the alternator repository.

Cloning manually returned an error.

```

reload@roedovre:~$ git clone 'http://github.com/dingproject/alternator.git' '/tmp/test'
Initialized empty Git repository in /tmp/test/.git/
error: RPC failed; result=22, HTTP code = 400
```

It worked with https

```
reload@roedovre:~$ git clone 'https://github.com/dingproject/alternator.git' '/tmp/test'
Initialized empty Git repository in /tmp/test/.git/
remote: Counting objects: 574, done.
```

It seems that something was changed on github, though I can't find any documentation.
